### PR TITLE
Add options to leave airdate blank for negative seasons

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -348,8 +348,13 @@ class ShokoRelayAgent:
             # Get Originally Available
             airdate = try_get(episode_data['AniDB'], 'AirDate', None)
             if airdate:
-                episode_obj.originally_available_at = datetime.strptime(airdate, '%Y-%m-%d').date()
-                Log('Originally Available:          %s' % episode_obj.originally_available_at)
+                if (season == -4 and Prefs['disableOtherSeasonAirdate']):
+                    Log('Originally Available:          (skipped)')
+                elif (-3 <= season and season < 0 and Prefs['disableNegativeSeasonAirdate']):
+                    Log('Originally Available:          (skipped)')
+                else:
+                    episode_obj.originally_available_at = datetime.strptime(airdate, '%Y-%m-%d').date()
+                    Log('Originally Available:          %s' % episode_obj.originally_available_at)
 
             # Get Content Ratings (from series)
             episode_obj.content_rating = metadata.content_rating

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -119,5 +119,17 @@
         "label": "Use Shoko's episode thumbnails",
         "type": "bool",
         "default": false
+    },
+    {
+        "id": "disableNegativeSeasonAirdate",
+        "label": "Leave 'Originally Available' date blank for theme songs, trailers, and parodies. This is a workaround to prevent Plex from playing all of them before episodes",
+        "type": "bool",
+        "default": false
+    },
+    {
+        "id": "disableOtherSeasonAirdate",
+        "label": "Leave 'Originally Available' date blank for episodes of type 'Other'. This is a workaround to prevent Plex from playing all of them before episodes",
+        "type": "bool",
+        "default": false
     }
 ]


### PR DESCRIPTION
Plex has a bug that causes (all) episodes in negative seasons to be queued before a selected episode is played. This happens when clicking play at the series level, season level, and episode level. Only episodes in negative seasons with an airdate (`Originally Available`) date that is later than the selected episode. Setting the airdate to be blank fixes this issue. 

This PR adds the option to leave the originally aired field blank for seasons -1, -2, -3 (theme songs, trailers, parodies)(`disableNegativeSeasonAirdate`) and a separate setting for season -4 (other) (`disableOtherSeasonAirdate`). 

When the airdate is left blank, episodes are excluded from Plex's chronological playback mechanism, and instead will play in numerical order.

