### PR TITLE
Feat: Fix sorting of series where new seasons only append the year

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -93,7 +93,7 @@ class ShokoRelayAgent:
             if alt_title: break
 
         # Append the Alternate title to the Sort Title to make it searchable
-        if alt_title and alt_title != metadata.title: metadata.title_sort = title + ' [' + alt_title + ']'
+        if alt_title and alt_title != metadata.title: metadata.title_sort = title + ' ! [' + alt_title + ']'
         else: alt_title, metadata.title_sort = 'Alternate Title Matches the Title - Skipping!', title
         Log('Alt Title (AddToSort) [LANG]:  %s [%s]' % (alt_title, lang.upper()))
 


### PR DESCRIPTION
AniDB will sometime name split-cour or individual seasons of a long running series as "Series (year)". 

For example:
- [Tonikaku Kawaii](https://anidb.net/anime/15421)
- [Tonikaku Kawaii (2023)](https://anidb.net/anime/16961)

To aid in searching, we append the series' alt-title to the end of the Sort Title in brackets. However, when sorting, the parenthesis will sort before the the square bracket does. This results in weird sorting for titles like the above. 

Plex will sort: 
- `Tonikaku Kawaii (2023) [Tonikawa: Over the Moon for You (2023)]` 
- `Tonikaku Kawaii [Tonikawa: Over the Moon for You]`

This simply appends an exclamation mark prior to appending the alt-title. This way, shows without the year appended will always sort first thanks to the exclamation mark having higher precedence.